### PR TITLE
Add a workaround for the std::this_thread::yield bug in g++ 4.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,21 @@ if(HAS_PTHREAD)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 endif(HAS_PTHREAD)
 
+# Add a workaround for the g++ bug
+# c.f. http://gcc.gnu.org/bugzilla/show_bug.cgi?id=52680
+#      http://gcc.gnu.org/ml/libstdc++-cvs/2012-q4/msg00045.html
+if (${CMAKE_SYSTEM} MATCHES "Linux")
+    # Try to use std::this_thread::yield()
+    include(CheckCXXSourceCompiles)
+    CHECK_CXX_SOURCE_COMPILES(
+        "#include <thread> int main(int argc, const char** argv) { std::this_thread::yield(); return 0; }"
+        STD_THREAD_YIELD_CAN_BE_USED
+    )
+    if (NOT STD_THREAD_YIELD_CAN_BE_USED)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_NANOSLEEP -D_GLIBCXX_USE_SCHED_YIELD")
+    endif()
+endif()
+
 set(SIGNALS_CPP_3RD_PARTY_DIR ${CMAKE_CURRENT_SOURCE_DIR}/3rdParty)
 
 SET(EXECUTABLE_OUTPUT_PATH         ${CMAKE_BINARY_DIR}/bin)


### PR DESCRIPTION
c.f. http://gcc.gnu.org/bugzilla/show_bug.cgi?id=52680
http://gcc.gnu.org/ml/libstdc++-cvs/2012-q4/msg00045.html
