### PR TITLE
VS2015

### DIFF
--- a/config-VS2012-win64.bat
+++ b/config-VS2012-win64.bat
@@ -1,0 +1,2 @@
+@echo off
+cmake -H. -BBuild -G "Visual Studio 11 2012" -A x64

--- a/config-VS2015-win64.bat
+++ b/config-VS2015-win64.bat
@@ -1,0 +1,2 @@
+@echo off
+cmake -H. -BBuild -G "Visual Studio 14 2015" -A x64

--- a/config-win64.bat
+++ b/config-win64.bat
@@ -1,2 +1,0 @@
-@echo off
-cmake -H. -BBuild -G "Visual Studio 11 Win64"

--- a/signals-cpp/connection.hpp
+++ b/signals-cpp/connection.hpp
@@ -23,11 +23,11 @@
 
 #pragma once
 
-#include "config.hpp"
-
 #include <atomic>
 #include <memory>
 #include <thread>
+
+#include "config.hpp"
 
 namespace signals {
 

--- a/signals-cpp/connections.hpp
+++ b/signals-cpp/connections.hpp
@@ -23,9 +23,10 @@
 
 #pragma once
 
-#include "signal.hpp"
-
 #include <utility>
+#include <vector>
+
+#include "connection.hpp"
 
 namespace signals {
 
@@ -50,7 +51,7 @@ namespace signals {
         /// Connects to the given `signal` `s` and adds the created `connection` to
         /// the list of tracked connections.
         template<typename SIGNAL, typename... ARGS>
-        inline connection connect(SIGNAL& s, ARGS&&... args) {
+		inline connection connect(SIGNAL& s, ARGS&&... args) {
             auto conn = s.connect(std::forward<ARGS>(args)...);
             add(conn);
             return conn;
@@ -59,13 +60,13 @@ namespace signals {
 #else //  defined(SIGNALS_CPP_HAVE_VARIADIC_TEMPLATES)
 
         template<typename SIGNAL, typename ARG1>
-        inline connection connect(SIGNAL& s, ARG1&& arg1) {
+		inline connection connect(SIGNAL& s, ARG1&& arg1) {
             auto conn = s.connect(std::forward<ARG1>(arg1));
             add(conn);
             return conn;
         }
 
-        template<typename SIGNAL, typename ARG1, typename ARG2>
+		template<typename SIGNAL, typename ARG1, typename ARG2>
         inline connection connect(SIGNAL& s, ARG1&& arg1, ARG2&& arg2) {
             auto conn = s.connect(std::forward<ARG1>(arg1), std::forward<ARG2>(arg2));
             add(conn);

--- a/signals-cpp/connections.hpp
+++ b/signals-cpp/connections.hpp
@@ -51,7 +51,7 @@ namespace signals {
         /// Connects to the given `signal` `s` and adds the created `connection` to
         /// the list of tracked connections.
         template<typename SIGNAL, typename... ARGS>
-		inline connection connect(SIGNAL& s, ARGS&&... args) {
+        inline connection connect(SIGNAL& s, ARGS&&... args) {
             auto conn = s.connect(std::forward<ARGS>(args)...);
             add(conn);
             return conn;
@@ -60,13 +60,13 @@ namespace signals {
 #else //  defined(SIGNALS_CPP_HAVE_VARIADIC_TEMPLATES)
 
         template<typename SIGNAL, typename ARG1>
-		inline connection connect(SIGNAL& s, ARG1&& arg1) {
+        inline connection connect(SIGNAL& s, ARG1&& arg1) {
             auto conn = s.connect(std::forward<ARG1>(arg1));
             add(conn);
             return conn;
         }
 
-		template<typename SIGNAL, typename ARG1, typename ARG2>
+        template<typename SIGNAL, typename ARG1, typename ARG2>
         inline connection connect(SIGNAL& s, ARG1&& arg1, ARG2&& arg2) {
             auto conn = s.connect(std::forward<ARG1>(arg1), std::forward<ARG2>(arg2));
             add(conn);

--- a/signals-cpp/signal.hpp
+++ b/signals-cpp/signal.hpp
@@ -23,14 +23,14 @@
 
 #pragma once
 
-#include "connection.hpp"
-
 #include <algorithm>
 #include <cassert>
 #include <functional>
 #include <memory>
 #include <mutex>
 #include <vector>
+
+#include "connections.hpp"
 
 namespace signals {
 

--- a/signals-cpp/signals.hpp
+++ b/signals-cpp/signals.hpp
@@ -23,19 +23,7 @@
 
 #pragma once
 
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-#  define SIGNALS_CPP_NOEXCEPT throw()
-#else // defined(_MSC_VER) && (_MSC_VER < 1900)
-#  define SIGNALS_CPP_NOEXCEPT noexcept
-#endif // defined(_MSC_VER) && (_MSC_VER < 1900)
-
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-#  define SIGNALS_CPP_NEED_EXPLICIT_MOVE
-#endif // defined(_MSC_VER) && (_MSC_VER < 1900)
-
-#if defined(__clang__) || (defined(_MSC_VER) && (_MSC_VER >= 1900))
-#  define SIGNALS_CPP_HAVE_VARIADIC_TEMPLATES
-#endif
-
-namespace signals { }
-namespace sigs = signals;
+#include "config.hpp"
+#include "connection.hpp"
+#include "connections.hpp"
+#include "signal.hpp"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(
 	../signals-cpp/connection.hpp
 	../signals-cpp/connections.hpp
 	../signals-cpp/signal.hpp
+	../signals-cpp/signals.hpp
 )
 	 
 add_test(

--- a/test/signals_unittests.cpp
+++ b/test/signals_unittests.cpp
@@ -23,7 +23,7 @@
 
 #include <cute/cute.hpp>
 
-#include <signals-cpp/connections.hpp>
+#include <signals-cpp/signals.hpp>
 
 CUTE_TEST(
     "test a single simple connection",


### PR DESCRIPTION
1) shuffle some of the includes around to get the code also compile with VS2015
2) please use `#include <signals-cpp/signals.hpp>` in order to include this library